### PR TITLE
[bug] : 사용자 주문 수정시 총 가격이 업데이트되지 않는 오류 수정

### DIFF
--- a/backend/src/main/java/com/team2/demo/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/controller/OrderController.java
@@ -98,9 +98,10 @@ public class OrderController {
     public RsData<OrderDto> updateOrder(
             @PathVariable String orderId,
             @RequestParam String email,
-            @RequestBody OrderRequestDto request) {
-        RsData<OrderDto> response = orderService.updateOrder(orderId, email, request);
-        return response;
+            @Valid @RequestBody OrderRequestDto request) {
+        OrderDto response = orderService.updateOrder(orderId, email, request);
+
+        return RsData.success("ok", response);
     }
 
     /*

--- a/backend/src/main/java/com/team2/demo/domain/order/dto/OrderRequestDto.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/dto/OrderRequestDto.java
@@ -1,21 +1,25 @@
 package com.team2.demo.domain.order.dto;
 
+import com.team2.demo.domain.product.dto.ProductListDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class OrderRequestDto {
+
     @NotBlank(message = "배송 주소를 입력해야 합니다.")
-    private String deliveryAddress;
+    private String address;
 
     @NotNull(message = "우편번호를 입력해야 합니다.")
-    private Integer zipCode;
+    private Integer zipcode;
 
     @NotNull(message = "상품 ID 리스트는 필수입니다.")
-    private List<String> productIds;
-
+    private List<ProductListDto> items;
 }

--- a/backend/src/main/java/com/team2/demo/domain/order/dto/ProductWithAmount.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/dto/ProductWithAmount.java
@@ -1,0 +1,11 @@
+package com.team2.demo.domain.order.dto;
+
+import com.team2.demo.domain.product.entity.Product;
+
+/**
+ * 주문 내 물품의 수량과 아이템 엔티티를 저장하는 레코드
+ * @param product
+ * @param amount
+ */
+public record ProductWithAmount(Product product, int amount){
+}

--- a/backend/src/main/java/com/team2/demo/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/entity/Order.java
@@ -83,6 +83,23 @@ public class Order {
         this.modifiedDate = LocalDateTime.now();
     }
 
+    public void updateOrder(List<Product> updatedProducts, String address, Integer zipCode, DeliveryStatus deliveryStatus) {
+        int totalPrice = calculateTotalPrice(updatedProducts);
+        this.totalAmount = totalPrice;
+        this.deliveryAddress= address;
+        this.zipCode = zipCode;
+        this.deliveryStatus = deliveryStatus;
+        this.modifiedDate = LocalDateTime.now();
+    }
+
+    private static int calculateTotalPrice(List<Product> updatedProducts) {
+        int totalPrice = 0;
+        for(Product item : updatedProducts){
+            totalPrice += item.getProductPrice();
+        }
+        return totalPrice;
+    }
+
     public enum DeliveryStatus {
         PENDING, SHIPPED, DELIVERED, CANCELLED
     }

--- a/backend/src/main/java/com/team2/demo/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/entity/Order.java
@@ -91,6 +91,8 @@ public class Order {
         this.zipCode = zipCode;
         this.deliveryStatus = deliveryStatus;
         this.modifiedDate = LocalDateTime.now();
+        this.products.clear();
+        this.products.addAll(updatedProducts.stream().map(ProductWithAmount::product).toList());
     }
 
     private static int calculateTotalPrice(List<ProductWithAmount> updatedProducts) {

--- a/backend/src/main/java/com/team2/demo/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/entity/Order.java
@@ -1,5 +1,6 @@
 package com.team2.demo.domain.order.entity;
 
+import com.team2.demo.domain.order.dto.ProductWithAmount;
 import com.team2.demo.domain.product.entity.Product;
 import com.team2.demo.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -83,7 +84,7 @@ public class Order {
         this.modifiedDate = LocalDateTime.now();
     }
 
-    public void updateOrder(List<Product> updatedProducts, String address, Integer zipCode, DeliveryStatus deliveryStatus) {
+    public void updateOrder(List<ProductWithAmount> updatedProducts, String address, Integer zipCode, DeliveryStatus deliveryStatus) {
         int totalPrice = calculateTotalPrice(updatedProducts);
         this.totalAmount = totalPrice;
         this.deliveryAddress= address;
@@ -92,10 +93,10 @@ public class Order {
         this.modifiedDate = LocalDateTime.now();
     }
 
-    private static int calculateTotalPrice(List<Product> updatedProducts) {
+    private static int calculateTotalPrice(List<ProductWithAmount> updatedProducts) {
         int totalPrice = 0;
-        for(Product item : updatedProducts){
-            totalPrice += item.getProductPrice();
+        for(ProductWithAmount item : updatedProducts){
+            totalPrice += item.product().getProductPrice()*item.amount();
         }
         return totalPrice;
     }

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -2,13 +2,17 @@ package com.team2.demo.domain.order.service;
 
 import com.team2.demo.domain.order.controller.OrderController;
 import com.team2.demo.domain.order.dto.OrderDto;
-import com.team2.demo.domain.order.dto.OrderItemGrouper;
 import com.team2.demo.domain.order.dto.OrderInfoWithoutItemDto;
+import com.team2.demo.domain.order.dto.OrderItemGrouper;
 import com.team2.demo.domain.order.dto.OrderRequestDto;
 import com.team2.demo.domain.order.entity.Order;
 import com.team2.demo.domain.order.repository.OrderRepository;
 import com.team2.demo.domain.product.entity.Product;
 import com.team2.demo.domain.product.repository.ProductRepository;
+import com.team2.demo.domain.user.entity.User;
+import com.team2.demo.domain.user.repository.UserRepository;
+import com.team2.demo.global.exception.order.NoProductsInOrderException;
+import com.team2.demo.global.exception.user.AccessDeniedException;
 import com.team2.demo.global.response.RsData;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.constraints.NotEmpty;
@@ -30,6 +34,7 @@ import java.util.stream.Collectors;
 public class OrderService {
     private final OrderRepository orderRepository;
     private final ProductRepository productRepository;
+    private final UserRepository userRepository;
 
     // 사용자: 주문 리스트 조회
     public Page<OrderDto> getOrdersByEmail(OrderController.OrderForm orderForm, int page, int size) {
@@ -41,7 +46,7 @@ public class OrderService {
 
     // 사용자: 주문 수정
     @Transactional
-    public RsData<OrderDto> updateOrder(String orderId, String email, OrderRequestDto request) {
+    public OrderDto updateOrder(String orderId, String email, OrderRequestDto request) {
         Order order = orderRepository.findByOrderUuid(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 주문을 찾을 수 없습니다."));
 
@@ -50,32 +55,23 @@ public class OrderService {
         if(!loggedInUser.isMine(order))
             throw new AccessDeniedException("자신이 주문하지 않은 주문을 수정할 수 없습니다.");
 
-
         if (order.getDeliveryStatus() == Order.DeliveryStatus.SHIPPED ||
                 order.getDeliveryStatus() == Order.DeliveryStatus.DELIVERED) {
             throw new IllegalStateException("배송 중이거나 배송 완료한 주문은 수정할 수 없습니다.");
         }
 
-
-        List<Product> updatedProducts = request.getProductIds().stream()
-                .map(productUuid -> productRepository.findByProductUuid(productUuid)
+        List<Product> updatedProducts = request.getItems().stream()
+                .map(productUuid -> productRepository.findByProductUuid(productUuid.getProductId())
                         .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + productUuid)))
                 .collect(Collectors.toList());
-
-        order.updateProducts(updatedProducts); // clear() + addAll()
-
-        order.updateDeliveryInfo(request.getDeliveryAddress(), request.getZipCode());
-
-        order.updateModifiedDate();
-
-        orderRepository.save(order);
 
         if (updatedProducts.isEmpty()) {
             order.updateDeliveryStatus(Order.DeliveryStatus.CANCELLED);
             throw new NoProductsInOrderException("주문에 상품이 하나도 없어 주문이 취소되었습니다.");
         }
+        order.updateOrder(updatedProducts, request.getAddress(), request.getZipcode(), order.getDeliveryStatus());
 
-        return RsData.success("주문이 수정되었습니다.", new OrderDto(order));
+        return new OrderDto(order);
     }
 
     // 관리자: 주문 리스트 조회

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -53,7 +53,7 @@ public class OrderService {
 
         if (order.getDeliveryStatus() == Order.DeliveryStatus.SHIPPED ||
                 order.getDeliveryStatus() == Order.DeliveryStatus.DELIVERED) {
-            return RsData.badRequest("배송 중이거나 배송 완료된 주문은 수정할 수 없습니다.", 400);
+            throw new IllegalStateException("배송 중이거나 배송 완료한 주문은 수정할 수 없습니다.");
         }
 
 

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -1,13 +1,9 @@
 package com.team2.demo.domain.order.service;
 
 import com.team2.demo.domain.order.controller.OrderController;
-import com.team2.demo.domain.order.dto.OrderDto;
-import com.team2.demo.domain.order.dto.OrderInfoWithoutItemDto;
-import com.team2.demo.domain.order.dto.OrderItemGrouper;
-import com.team2.demo.domain.order.dto.OrderRequestDto;
+import com.team2.demo.domain.order.dto.*;
 import com.team2.demo.domain.order.entity.Order;
 import com.team2.demo.domain.order.repository.OrderRepository;
-import com.team2.demo.domain.product.entity.Product;
 import com.team2.demo.domain.product.repository.ProductRepository;
 import com.team2.demo.domain.user.entity.User;
 import com.team2.demo.domain.user.repository.UserRepository;
@@ -60,16 +56,20 @@ public class OrderService {
             throw new IllegalStateException("배송 중이거나 배송 완료한 주문은 수정할 수 없습니다.");
         }
 
-        List<Product> updatedProducts = request.getItems().stream()
-                .map(productUuid -> productRepository.findByProductUuid(productUuid.getProductId())
-                        .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + productUuid)))
-                .collect(Collectors.toList());
+        List<ProductWithAmount> updatedProducts = request.getItems().stream()
+                .map(item ->
+                                new ProductWithAmount(
+                                        productRepository.findByProductUuid(item.getProductId())
+                                                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + item.getProductId()))
+                                        , item.getQuantity()))
+                        .collect(Collectors.toList());
 
         if (updatedProducts.isEmpty()) {
             order.updateDeliveryStatus(Order.DeliveryStatus.CANCELLED);
             throw new NoProductsInOrderException("주문에 상품이 하나도 없어 주문이 취소되었습니다.");
         }
-        order.updateOrder(updatedProducts, request.getAddress(), request.getZipcode(), order.getDeliveryStatus());
+
+        order.updateOrder(updatedProducts,  request.getAddress(), request.getZipcode(), order.getDeliveryStatus());
 
         return new OrderDto(order);
     }

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -72,8 +72,7 @@ public class OrderService {
 
         if (updatedProducts.isEmpty()) {
             order.updateDeliveryStatus(Order.DeliveryStatus.CANCELLED);
-            orderRepository.delete(order);
-            return RsData.success("주문이 취소되었습니다.", null);
+            throw new NoProductsInOrderException("주문에 상품이 하나도 없어 주문이 취소되었습니다.");
         }
 
         return RsData.success("주문이 수정되었습니다.", new OrderDto(order));

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -45,6 +45,11 @@ public class OrderService {
         Order order = orderRepository.findByOrderUuid(orderId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 주문을 찾을 수 없습니다."));
 
+        User loggedInUser = userRepository.findByEmail(email);
+
+        if(!loggedInUser.isMine(order))
+            throw new AccessDeniedException("자신이 주문하지 않은 주문을 수정할 수 없습니다.");
+
 
         if (order.getDeliveryStatus() == Order.DeliveryStatus.SHIPPED ||
                 order.getDeliveryStatus() == Order.DeliveryStatus.DELIVERED) {

--- a/backend/src/main/java/com/team2/demo/domain/product/dto/ProductListDto.java
+++ b/backend/src/main/java/com/team2/demo/domain/product/dto/ProductListDto.java
@@ -1,0 +1,12 @@
+package com.team2.demo.domain.product.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductListDto {
+
+    private String productId;
+    private int quantity;
+}

--- a/backend/src/main/java/com/team2/demo/domain/user/entity/User.java
+++ b/backend/src/main/java/com/team2/demo/domain/user/entity/User.java
@@ -43,4 +43,7 @@ public class User {
     @Builder.Default
     private final List<Order> orders = new ArrayList<>();
 
+    public boolean isMine(Order order) {
+        return order.getUser().equals(this);
+    }
 }

--- a/backend/src/main/java/com/team2/demo/domain/user/entity/User.java
+++ b/backend/src/main/java/com/team2/demo/domain/user/entity/User.java
@@ -11,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -45,5 +46,16 @@ public class User {
 
     public boolean isMine(Order order) {
         return order.getUser().equals(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof User user)) return false;
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/backend/src/main/java/com/team2/demo/global/exception/ServiceException.java
+++ b/backend/src/main/java/com/team2/demo/global/exception/ServiceException.java
@@ -1,4 +1,7 @@
 package com.team2.demo.global.exception;
 
-public class ServiceException {
+public class ServiceException extends RuntimeException{
+    public ServiceException(String message) {
+        super(message);
+    }
 }

--- a/backend/src/main/java/com/team2/demo/global/exception/order/NoProductsInOrderException.java
+++ b/backend/src/main/java/com/team2/demo/global/exception/order/NoProductsInOrderException.java
@@ -1,0 +1,9 @@
+package com.team2.demo.global.exception.order;
+
+import com.team2.demo.global.exception.ServiceException;
+
+public class NoProductsInOrderException extends ServiceException {
+    public NoProductsInOrderException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/team2/demo/global/exception/user/AccessDeniedException.java
+++ b/backend/src/main/java/com/team2/demo/global/exception/user/AccessDeniedException.java
@@ -1,0 +1,9 @@
+package com.team2.demo.global.exception.user;
+
+import com.team2.demo.global.exception.ServiceException;
+
+public class AccessDeniedException extends ServiceException {
+    public AccessDeniedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

API 문서와 바디 파라미터가 다른 것을 같도록 수정함.

사용자 주문 수정시 발생하는 에러들을 생성하고 일단은 던지도록 작성
추후에 이 던진 에러들을 잡아주는 핸들러를 GlobalExceptionAdvisor에 작성해야 함.

사용자 주문 수정시 파라미터를 `@Valid`로 컨트롤러에서 처리함.

사용자 주문 수정시 자신이 생성하지 않은 주문에 대해서 수정하지 못하도록 exception을 던짐

사용자 주문 수정시 총 가격이 업데이트 되지 않는 것을 수정함.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링(성능, 기능 메서드)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
