### PR TITLE
[bug] : OrderControllerAdmin에서 Order 객체를 파라미터에 그대로 노출시키는 문제 해결

### DIFF
--- a/backend/src/main/java/com/team2/demo/domain/order/controller/OrderControllerAdmin.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/controller/OrderControllerAdmin.java
@@ -2,7 +2,7 @@ package com.team2.demo.domain.order.controller;
 
 import com.team2.demo.domain.order.dto.OrderDto;
 import com.team2.demo.domain.order.dto.OrderInfoWithoutItemDto;
-import com.team2.demo.domain.order.entity.Order;
+import com.team2.demo.domain.order.dto.OrderRequestDto;
 import com.team2.demo.domain.order.service.AdminOrderService;
 import com.team2.demo.domain.order.service.OrderService;
 import com.team2.demo.domain.product.service.ProductService;
@@ -24,7 +24,6 @@ public class OrderControllerAdmin {
 
     private final OrderService orderService;
     private final AdminOrderService adminOrderService;
-    private final ProductService productService;
 
 
     /*
@@ -50,11 +49,11 @@ public class OrderControllerAdmin {
         return RsData.success("ok", response);
     }
 
-    @Operation(summary = "주문 수저", description = "특정 유저의 주문을 수정한다.")
+    @Operation(summary = "주문 수정", description = "특정 유저의 주문을 수정한다.")
     @PutMapping("/{orderUuid}")
     public RsData<OrderDto> updateOrder(
             @PathVariable String orderUuid,
-            @RequestBody Order order) {
+            @RequestBody OrderRequestDto order) {
         OrderDto updateOrder = adminOrderService.updateOrder(orderUuid, order);
         return RsData.success("success.", updateOrder);
     }

--- a/backend/src/main/java/com/team2/demo/domain/order/service/AdminOrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/AdminOrderService.java
@@ -1,13 +1,21 @@
 package com.team2.demo.domain.order.service;
 
 import com.team2.demo.domain.order.dto.OrderDto;
+import com.team2.demo.domain.order.dto.OrderRequestDto;
+import com.team2.demo.domain.order.dto.ProductWithAmount;
 import com.team2.demo.domain.order.entity.Order;
 import com.team2.demo.domain.order.repository.OrderRepository;
+import com.team2.demo.domain.product.entity.Product;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.weaver.ast.Or;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -16,17 +24,26 @@ public class AdminOrderService {
     private final OrderRepository orderRepository;
 
     @Transactional
-    public OrderDto updateOrder(String orderId, Order request) {
+    public OrderDto updateOrder(String orderId, OrderRequestDto request) {
         Order order = orderRepository.findById(orderId).
                 orElseThrow(() -> new EntityNotFoundException("주문을 찾을 수 없습니다: " + orderId));
 
+        Map<Product, Integer> productAmounts = new HashMap<>();
+
+        for(Product product : order.getProducts()){
+            if( productAmounts.containsKey(product)) {
+                productAmounts.put(product, productAmounts.get(product) + 1);
+            }else{
+                productAmounts.put(product, 1);
+            }
+        }
+
+        List<ProductWithAmount> productWithAmounts = productAmounts.entrySet().stream().map(
+                entry -> new ProductWithAmount(entry.getKey(), entry.getValue())
+        ).toList();
+
         //주문 정보 업데이트
-        order.updateOrder(
-                request.getTotalAmount(),
-                request.getDeliveryAddress(),
-                request.getZipCode(),
-                request.getDeliveryStatus()
-        );
+        order.updateOrder(productWithAmounts, request.getAddress(), request.getZipcode(), order.getDeliveryStatus() );
         return new OrderDto(order);
     }
 

--- a/backend/src/main/java/com/team2/demo/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/team2/demo/domain/product/entity/Product.java
@@ -3,6 +3,8 @@ package com.team2.demo.domain.product.entity; // Order 와 다른 패키지에 �
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.Objects;
+
 @Entity
 @Table(name = "PRODUCT")
 @Getter
@@ -30,4 +32,14 @@ public class Product {
     @Column(name = "IMAGE_URL")
     private String imageUrl;
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Product product)) return false;
+        return Objects.equals(productUuid, product.productUuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(productUuid);
+    }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Order 객체 대신 ORderReqDto를 받도록 했고

service 객체에서 order 내부 products를 연관관계로 끌어 가져와 처리함

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링(성능, 기능 메서드)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
