### PR TITLE
[bug] : BE - 주문 취소 (사용자) 응답 수정

### DIFF
--- a/backend/src/main/java/com/team2/demo/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/controller/OrderController.java
@@ -1,9 +1,6 @@
 package com.team2.demo.domain.order.controller;
 
-import com.team2.demo.domain.order.dto.OrderDto;
-import com.team2.demo.domain.order.dto.OrderInfoDto;
-import com.team2.demo.domain.order.dto.OrderInfoWithoutItemDto;
-import com.team2.demo.domain.order.dto.OrderRequestDto;
+import com.team2.demo.domain.order.dto.*;
 import com.team2.demo.domain.order.entity.Order;
 import com.team2.demo.domain.order.service.OrderService;
 import com.team2.demo.domain.user.entity.User;
@@ -117,17 +114,17 @@ public class OrderController {
 
         return RsData.success("ok", response);
     }
+
     /*
     사용자 주문 취소
      DELETE /orders/{orderId}?email=user@example.com
     */
     @Operation(summary = "주문 삭제 ", description = "사용자가 자신이 생성한 주문을 삭제한다.")
     @DeleteMapping("/{orderId}")
-    public RsData<Void> cancelOrder(
+    public RsData<OrderResponseCancelDto> cancelOrder(
             @PathVariable String orderId,
             @RequestParam String email) {
-        RsData<Void> response = orderService.cancelOrder(orderId, email);
-        return response;
+        return orderService.cancelOrder(orderId, email);
     }
 }
 

--- a/backend/src/main/java/com/team2/demo/domain/order/dto/OrderResponseCancelDto.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/dto/OrderResponseCancelDto.java
@@ -1,0 +1,13 @@
+package com.team2.demo.domain.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OrderResponseCancelDto {
+    private String orderId;
+    private String message;
+}

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -60,7 +60,7 @@ public class OrderService {
 
         if (order.getDeliveryStatus() == Order.DeliveryStatus.SHIPPED ||
                 order.getDeliveryStatus() == Order.DeliveryStatus.DELIVERED) {
-            throw new IllegalStateException("배송 중이거나 배송 완료한 주문은 수정할 수 없습니다.");
+            throw new IllegalStateException("배송 중이거나 배송 완료된 주문은 수정할 수 없습니다.");
         }
 
         List<ProductWithAmount> updatedProducts = request.getItems().stream()

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -1,13 +1,11 @@
 package com.team2.demo.domain.order.service;
 
-import com.team2.demo.domain.order.controller.OrderController;
 import com.team2.demo.domain.order.dto.*;
 import com.team2.demo.domain.order.entity.Order;
 import com.team2.demo.domain.order.repository.OrderRepository;
 import com.team2.demo.domain.product.dto.ProductListDto;
 import com.team2.demo.domain.product.entity.Product;
 import com.team2.demo.domain.product.repository.ProductRepository;
-import com.team2.demo.domain.product.service.ProductService;
 import com.team2.demo.domain.user.entity.User;
 import com.team2.demo.domain.user.repository.UserRepository;
 import com.team2.demo.domain.user.service.UserService;
@@ -19,7 +17,6 @@ import com.team2.demo.global.response.RsData;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.hibernate.service.spi.ServiceException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -146,11 +143,11 @@ public class OrderService {
 
     // 사용자: 주문 취소
     @Transactional
-    public RsData<Void> cancelOrder(String orderId, String email) {
+    public RsData<OrderResponseCancelDto> cancelOrder(String orderId, String email) {
         Optional<Order> optionalOrder = orderRepository.findByOrderUuid(orderId);
 
         if (optionalOrder.isEmpty()) {
-            return RsData.badRequest("해당 주문을 찾을 수 없습니다.", 404);
+            return RsData.badRequest("해당하는 주문을 찾을 수 없어 삭제에 실패했습니다.", 404);
         }
 
         Order order = optionalOrder.get();
@@ -160,9 +157,14 @@ public class OrderService {
         }
 
         order.updateDeliveryStatus(Order.DeliveryStatus.CANCELLED);
-        orderRepository.save(order);
 
-        return RsData.success("주문이 취소되었습니다.", null);
+
+        OrderResponseCancelDto responseDto = OrderResponseCancelDto.builder()
+                .orderId(order.getOrderUuid())
+                .message("주문이 성공적으로 취소되었습니다.")
+                .build();
+
+        return RsData.success("주문이 성공적으로 취소되었습니다.", responseDto);
     }
 
     public OrderInfoWithoutItemDto findOrder(String orderId, String email) {

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -154,7 +154,7 @@ public class OrderService {
 
         User user = userService.findByEmail(email);
         if (!user.isMine(order)) {
-            return RsData.badRequest("주문 취소 권한이 없습니다.", 403);
+            return new RsData<>("주문 취소 권한이 없습니다.", null, 403);
         }
 
         if (order.getDeliveryStatus() == Order.DeliveryStatus.SHIPPED ||

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -151,13 +151,18 @@ public class OrderService {
         }
 
         Order order = optionalOrder.get();
+
+        User user = userService.findByEmail(email);
+        if (!user.isMine(order)) {
+            return RsData.badRequest("주문 취소 권한이 없습니다.", 403);
+        }
+
         if (order.getDeliveryStatus() == Order.DeliveryStatus.SHIPPED ||
                 order.getDeliveryStatus() == Order.DeliveryStatus.DELIVERED) {
             return RsData.badRequest("배송 중이거나 배송 완료된 주문은 취소할 수 없습니다.", 400);
         }
 
         order.updateDeliveryStatus(Order.DeliveryStatus.CANCELLED);
-
 
         OrderResponseCancelDto responseDto = OrderResponseCancelDto.builder()
                 .orderId(order.getOrderUuid())

--- a/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
+++ b/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
@@ -260,7 +260,60 @@ class OrderControllerTest {
                         .content(requestJson))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("ok"))
-                .andExpect(jsonPath("$.data.orderId").value(orderId));
+                .andExpect(jsonPath("$.data.orderId").value(orderId))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("주문 수정 - 배송 중, 배송 완료 수정 불가")
+    public void updateOrder_FailDeliveryStatus() throws Exception {
+        String orderId = "order-11111-22222-33333";
+        String email = "email2@email.com";
+        String requestJson = String.format("""
+            {
+                "address": "updated addr for shipped order",
+                "zipcode": 789789,
+                "items": [
+                    {"productId": "product-11111-22222-33331", "quantity": 1}
+                ],
+                "buyer": {
+                    "email": "%s"
+                }
+            }
+            """, email);
+
+        mvc.perform(put("/orders/" + orderId)
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("배송 중이거나 배송 완료한 주문은 수정할 수 없습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("주문 수정 - 주문 상품 모두 삭제로 주문 취소")
+    public void updateOrderFailureTest_EmptyItems() throws Exception {
+        String orderId = "order-11111-22222-33332";
+        String email = "email1@email.com";
+        String requestJson = String.format("""
+            {
+                "address": "updated addr for empty items",
+                "zipcode": 999999,
+                "items": [],
+                "buyer": {
+                    "email": "%s"
+                }
+            }
+            """, email);
+
+        mvc.perform(put("/orders/" + orderId)
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("주문에 상품이 하나도 없어 주문이 취소되었습니다."))
+                .andDo(print());
     }
 
 }

--- a/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
+++ b/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
@@ -16,8 +16,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.List;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -313,6 +312,21 @@ class OrderControllerTest {
                         .content(requestJson))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("주문에 상품이 하나도 없어 주문이 취소되었습니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("주문 취소")
+    public void cancelOrder() throws Exception {
+        String orderId = "order-11111-22222-33331";
+        String email = "email1@email.com";
+
+        mvc.perform(delete("/orders/" + orderId)
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("주문이 성공적으로 취소되었습니다."))
+                .andExpect(jsonPath("$.data.orderId").value(orderId))
                 .andDo(print());
     }
 

--- a/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
+++ b/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -233,4 +234,33 @@ class OrderControllerTest {
                 .andExpect(status().isBadRequest())
                 .andDo(print());
     }
+
+    @Test
+    @DisplayName("주문 수정")
+    public void updateOrder() throws Exception {
+        String orderId = "order-11111-22222-33331";
+        String email = "email1@email.com";
+        String requestJson = String.format("""
+            {
+                "address": "updated addr",
+                "zipcode": 456456,
+                "items": [
+                    {"productId": "product-11111-22222-33331", "quantity": 3},
+                    {"productId": "product-11111-22222-33332", "quantity": 2}
+                ],
+                "buyer": {
+                    "email": "%s"
+                }
+            }
+            """, email);
+
+        mvc.perform(put("/orders/" + orderId)
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("ok"))
+                .andExpect(jsonPath("$.data.orderId").value(orderId));
+    }
+
 }

--- a/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
+++ b/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
@@ -266,7 +266,7 @@ class OrderControllerTest {
 
     @Test
     @DisplayName("주문 수정 - 배송 중, 배송 완료 수정 불가")
-    public void updateOrder_FailDeliveryStatus() throws Exception {
+    public void updateOrder2() throws Exception {
         String orderId = "order-11111-22222-33333";
         String email = "email2@email.com";
         String requestJson = String.format("""
@@ -293,7 +293,7 @@ class OrderControllerTest {
 
     @Test
     @DisplayName("주문 수정 - 주문 상품 모두 삭제로 주문 취소")
-    public void updateOrderFailureTest_EmptyItems() throws Exception {
+    public void updateOrder3() throws Exception {
         String orderId = "order-11111-22222-33332";
         String email = "email1@email.com";
         String requestJson = String.format("""


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
주문 취소 API의 응답 형식이 명세서와 맞지 않는 문제를 수정했습니다.
* 주문 취소 시 반환되는 응답을 명세서대로 수정
* `OrderResponseCancelDto` 정의, 응답 데이터에 `orderId`와 `message` 작성
* `OrderService`의 `cancelOrder` 수정
* `OrderController` 수정

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링(성능, 기능 메서드)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
