### PR TITLE
[bug] : 사용자 주문 생성시 order에 product가 들어가지 않는 오류

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -41,3 +41,5 @@ dt.trace.db
 src/main/resources/application.yml
 db_dev.mv.db
 db_dev.trace.db
+/apiV1.json
+/src/main/resources/application-dev.yml

--- a/backend/src/main/java/com/team2/demo/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/controller/OrderController.java
@@ -94,7 +94,7 @@ public class OrderController {
 
     @Operation(summary = "주문 생성 ", description = "사용자가 주문을 생성한다.")
     @PostMapping
-    public RsData<OrderInfoDto> payment(@RequestBody OrderRequestDto body) {
+    public RsData<OrderInfoDto> payment(@Valid @RequestBody OrderRequestDto body) {
 
         System.out.println("이메일조회"+body.getBuyer().getEmail());
 

--- a/backend/src/main/java/com/team2/demo/domain/order/dto/OrderRequestDto.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/dto/OrderRequestDto.java
@@ -3,7 +3,8 @@ package com.team2.demo.domain.order.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.team2.demo.domain.order.entity.Order;
 import com.team2.demo.domain.product.dto.ProductListDto;
-import com.team2.demo.domain.user.entity.User;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -11,7 +12,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -31,6 +31,7 @@ public class OrderRequestDto {
     private List<ProductListDto> items;
 
     @NotNull(message = "이메일 입력은 필수입니다.")
+    @Valid
     private Buyer buyer;
 
     // 엔티티 -> DTO 변환
@@ -45,6 +46,7 @@ public class OrderRequestDto {
 
     @Getter
     public class Buyer{
+        @Email
         private String email;
     }
 }

--- a/backend/src/main/java/com/team2/demo/domain/order/entity/Order.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/entity/Order.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.util.Pair;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -101,6 +102,14 @@ public class Order {
             totalPrice += item.product().getProductPrice()*item.amount();
         }
         return totalPrice;
+    }
+
+    public void addItems(List<Pair<Product, Integer>> productsInOrder) {
+        productsInOrder.forEach(pair -> {
+            for (int i = 0; i < pair.getSecond(); i++) {
+                products.add(pair.getFirst());
+            }
+        });
     }
 
     public enum DeliveryStatus {

--- a/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/team2/demo/domain/order/service/OrderService.java
@@ -25,10 +25,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -119,9 +121,11 @@ public class OrderService {
         int totalAmount = 0;
 
         List<ProductListDto> items = body.getItems();
+        List<Pair<Product, Integer>> productsInOrder = new ArrayList<>();
         for (ProductListDto item: items){
             Product product = productRepository.findByProductUuid(item.getProductId())
                     .orElseThrow(() -> new NoSuchProductException("id가 %s인 product는 없습니다."));
+            productsInOrder.add(Pair.of(product, item.getQuantity()));
             totalAmount += product.getProductPrice() * item.getQuantity();
         }
 
@@ -134,6 +138,8 @@ public class OrderService {
                 .zipCode(body.getZipcode())
                 .deliveryAddress(body.getAddress())
                 .build();
+
+        order.addItems(productsInOrder);
 
         return orderRepository.save(order);
     }

--- a/backend/src/main/java/com/team2/demo/domain/user/dto/UserDto.java
+++ b/backend/src/main/java/com/team2/demo/domain/user/dto/UserDto.java
@@ -3,9 +3,6 @@ package com.team2.demo.domain.user.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.team2.demo.domain.order.dto.OrderDto;
 import com.team2.demo.domain.user.entity.User;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,8 +22,6 @@ public class UserDto {
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
     private List<OrderDto> orders;
-    @Valid
-    private Buyer buyer;
 
     // 엔티티 -> DTO 변환
     public static UserDto of(User user) {
@@ -40,12 +35,4 @@ public class UserDto {
 //                        .collect(Collectors.toList()))
                 .build();
     }
-
-    @Getter
-    public class Buyer{
-        @NotNull(message = "이메일은 필수 값 입니다.")
-        @Email(message = "올바른 이메일 형식을 작성해주세요.")
-        private String email;
-    }
-
 }

--- a/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
+++ b/backend/src/test/java/com/team2/demo/domain/order/controller/OrderControllerTest.java
@@ -18,8 +18,7 @@ import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -179,7 +178,12 @@ class OrderControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonRequest))
                 .andExpect(status().isOk())
+                .andExpect(handler().methodName("payment"))
+                .andExpect(handler().handlerType(OrderController.class))
+                .andExpect(jsonPath("$.data.products").isArray())
+                .andExpect(jsonPath("$.data.totalAmount").value(3000))
                 .andDo(print());
+
     }
 
     @Test
@@ -209,7 +213,7 @@ class OrderControllerTest {
     }
 
     @Test
-    @DisplayName("주문 생성 - 제품 id 찾지 못함.")
+    @DisplayName("주문 생성 - email 형식 다름.")
     void paymentTest3() throws Exception{
         //초기 데이터
         String jsonRequest = """


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

주문 생성시 order에 product가 들어가지 않는 오류를 수정했습니다.
제가 전에 수정하다가 product 넣는 걸 까먹고 추가 안한 것 같네요

추가적으로 order 작성 시 buyer의 email 형식이 맞지 않을 때 validation하는 코드를 추가했습니다.

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링(성능, 기능 메서드)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
